### PR TITLE
Fix some clock hand display issues

### DIFF
--- a/src/ClockComponents.js
+++ b/src/ClockComponents.js
@@ -11,7 +11,7 @@ const ClockBaseBorder = styled.div`
             height: 100%;
             width: 100%;
             background-color: ${props => props.borderColor ? props.borderColor : "transparent"};
-            padding: ${props => props.border ? "5% 5% 5% 5%" : "0"};
+            padding: ${props => props.border ? "5%" : "0"};
             border-radius: 100%;
         `;
 const ClockBase = styled.div`
@@ -36,38 +36,37 @@ const ClockCenter = styled.div`
         `;
 
 const ClockHand = styled.div`
-            position: absolute;
-            top: 50%;
-            left: ${props => props.type === 'second' ? "40%" : "45%"};
+        box-sizing: border-box;
+        height: 1.5%;
+        min-height: 2px;
+        max-height: 6px;
 
             ${props => props.type === 'second' && css`
-                    width: 59.4%;
-                    outline: ${props => props.handColors && props.handColors.second ? "2px solid " + props.handColors.second : "2px solid #d81c7a"};
-                    transform-origin: 17%;
-                    transform: rotate(${props => props.handAngle}deg);
-                    transition: ${props => props.handAngle > 270 && 'transform 250ms ease-in-out'};
-                    // animation: ${props => props.secondStartAngle && sweep(props.secondStartAngle)} 60s linear 0s infinite;
+                    width: 60%;
+                    margin-left: 40%;
+                    background-color: ${props => props.handColors && props.handColors.second ? props.handColors.second : "#d81c7a" };
             `}
             ${props => props.type === 'minute' && css`
-                    width:45%;
-                    outline: ${props => props.handColors && props.handColors.minute ? "2px solid " + props.handColors.minute : "2px solid #fff"};
-                    transform-origin: 11.5%;
-                    transform: rotate(${props => props.handAngle}deg);
+                    width: 45%;
+                    margin-left: 45%;
+                    background-color: ${props => props.handColors && props.handColors.minute ? props.handColors.minute : "#fff" };
             `}
             ${props => props.type === 'hour' && css`
-                    width:35%;
-                    outline: ${props => props.handColors && props.handColors.hour ? "2px solid " + props.handColors.hour : "2px solid #fff"};
-                    transform-origin: 15%;
-                    transform: rotate(${props => props.handAngle}deg);
+                    width: 35%;
+                    margin-left: 45%;
+                    background-color: ${props => props.handColors && props.handColors.hour ? props.handColors.hour : "#fff" };
             `}
         `;
 
-const sweep = (secondStartAngle) => keyframes`
-    from {
-        transform: rotate(${secondStartAngle}deg)}
-    }
-    to {
-        transform: rotate(${secondStartAngle + 360}deg)}
-    }`
+const ClockHandContainer = styled.div`
+        position: absolute;
+        width: 100%
+        height: 100%;
+        display: flex;
+        align-items: center;
 
-export { ClockContainer, ClockBaseBorder, ClockBase, ClockCenter, ClockHand };
+        transform: rotate(${props => props.handAngle}deg);
+        transition: ${props => props.handAngle > 270 && 'transform 250ms ease-in-out'};
+    `;
+
+export { ClockContainer, ClockBaseBorder, ClockBase, ClockCenter, ClockHand, ClockHandContainer };

--- a/src/Form.js
+++ b/src/Form.js
@@ -78,8 +78,8 @@ class Form extends Component {
                 <div className="row">
                     <div className="col-4">
                         <div className="form-group">
-                            <label htmlFor="clock-size">Clock size (px)</label>
-                            <input type="range" min="200" max="500" className="form-control-range" id="clock-size" onChange={this.setClockSize} />
+                            <label htmlFor="clock-size">Clock size (px): {this.state.options.width}</label>
+                            <input type="range" min="50" max="500" className="form-control-range" id="clock-size" onChange={this.setClockSize} />
                         </div>
                         <div className="form-group">
                             <label htmlFor="border-req-radios">Use Custom Time?</label>

--- a/src/Hand.js
+++ b/src/Hand.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ClockHand } from './ClockComponents';
+import { ClockHand, ClockHandContainer } from './ClockComponents';
 import Util from './Util';
 
 class Hand extends Component {
@@ -9,19 +9,12 @@ class Hand extends Component {
         this.state = {};
     }
 
-    componentDidMount() {
-        if (this.props.type === 'second') {
-            let handAngle = (270 + (this.props.seconds * 6));
-            if (!this.state.secondStartAngle) {
-                this.setState({ secondStartAngle: handAngle });
-            }
-        }
-    }
-
     render() {
         return (
-            <ClockHand type={this.props.type} handAngle={Util.getHandAngle(this.props)} {...this.state}
-                handColors={this.props.handColors} />
+            <ClockHandContainer handAngle={Util.getHandAngle(this.props)} >
+                <ClockHand type={this.props.type}
+                    handColors={this.props.handColors} />
+            </ClockHandContainer>
         )
     }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3733911/97767006-9c262080-1ad6-11eb-900d-af1af29fd7eb.png)

![image](https://user-images.githubusercontent.com/3733911/97767014-a516f200-1ad6-11eb-9cf5-c98721a4efea.png)


This addresses issues 1 and 2 of the CSS issues in #17 !

For utility purposes I updated the clock generator slider to allow 50px min.

For the first issue, I set the clock hands to be 1.5% of the inner circle's width. Min at 2px, max at 6px.

For the second issue, it looked to be an issue with the transform-origin being a few decimals off. To reduce complexity I had all clock hands live in a box the same size as the inner clock in order to allow transform-origin to be the center. Then within the box, the clock hands are vertically centered using flexbox and then shifted with margin-left.

I found that the 3rd one would require more severe CSS changes to deal with odd numbers of pixels. Basically the clock would need to be a single circle with a CSS border, instead of 2 circles overlaid on each other. The inner circle snapping to the nearest pixel causes the centering issues for small clocks.

Also removed the "sweep"-related code as it doesn't look to be used at all anymore.

Tested on Win10 + Chrome, FF, Edge.